### PR TITLE
docs: add rc.9 online usage and live validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 本项目采用 [Semantic Versioning](https://semver.org/)。
 
-## [0.1.0-rc.9] - Unreleased
+## [0.1.0-rc.9] - 2026-08-03
 
 ### Added
 
@@ -31,7 +31,8 @@
 
 - `bash -n`、四资源档控制器/底层 fixture、六份模板生成一致性及状态/qdisc 故障注入测试已通过；
 - ShellCheck v0.11.0 已覆盖总控脚本、六份 profile 和测试脚本；
-- 固定 rc.9 Release 远程下载仍需在 Release assets 发布后验证；目标 VPS 的控制器生命周期测试仍待执行。
+- 固定 rc.9 Release 的八个资产已发布，并从公开下载地址重新下载后通过 `SHA256SUMS`；
+- Debian 13、1C1G、1000 Mbps、ext4 目标机已通过安全引导、首次 apply、安装 3X-UI 前重启验证、安装后严格验证及再次重启后的严格验证；重复 apply、rollback 和业务性能仍待执行。
 
 ## [0.1.0-rc.8] - 2026-08-02
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,159 @@
 
 脚本使用 BBR + fq、受控 TCP 缓冲、常规队列参数、应急 swap 和 journald 空间限制，目标是形成可预检、可验证、可重复执行、可回滚的配置。它不承诺在所有线路上提高吞吐或降低延迟。
 
-> 当前公开版本：`v0.1.0-rc.8`。本地源码正在准备下一候选版本 `v0.1.0-rc.9`，新增安全总控入口；rc.9 尚未提交或发布。正式 `v0.1.0` 还需要完成 [目标 VPS 运行验收](docs/validation.md)。
+> 当前公开版本：[`v0.1.0-rc.9`](https://github.com/alieismy/debian-vps-tuning/releases/tag/v0.1.0-rc.9)，标记为 Pre-release。正式 `v0.1.0` 仍需完成 [目标 VPS 运行验收](docs/validation.md)，不要把候选版本视为全平台、全带宽或性能验收已经完成。
 
-## 最简单的使用方式
+## 联网安装与验证
+
+以下命令均假定已经进入 VPS 的 root shell，提示符通常为 `#`，`id -u` 应输出 `0`。脚本会修改主机级网络、systemd、journald 和 swap 配置；首次执行前应确认服务商控制台或救援模式可用，并保存必要的基线信息。
+
+### 1. 联网安装
+
+推荐先执行 rc.9 固定 Release 的总控入口。它会自动识别 Debian 12/13、amd64、CPU 和内存档位，默认先执行只读 `preflight`，只有预检通过且再次明确输入 `y` 才执行 `apply`：
+
+```bash
+(
+  set -e
+
+  dvt_tmp="$(mktemp -d)"
+  trap 'rm -rf -- "$dvt_tmp"' EXIT
+
+  curl --fail --show-error --silent --location \
+    --proto '=https' \
+    --proto-redir '=https' \
+    --connect-timeout 15 \
+    --max-time 120 \
+    -o "$dvt_tmp/debian-vps-tuning.sh" \
+    https://github.com/alieismy/debian-vps-tuning/releases/download/v0.1.0-rc.9/debian-vps-tuning.sh
+
+  printf '%s  %s\n' \
+    '09cbb77591760fa1789729c31f64e03b29f145f50c8c419bca6057b23f492979' \
+    "$dvt_tmp/debian-vps-tuning.sh" | sha256sum -c -
+
+  bash "$dvt_tmp/debian-vps-tuning.sh"
+)
+```
+
+安全引导将：
+
+1. 显示检测到的系统、CPU、内存和档位；
+2. 选择服务商端口带宽，直接按 Enter 使用 200 Mbps；
+3. 显示实际调用脚本、来源和 SHA-256；
+4. 先执行只读 `preflight`；
+5. `preflight` 通过后再次询问，只有明确输入 `y` 才执行 `apply`。
+
+应用成功后按提示重启：
+
+```bash
+reboot
+```
+
+### 2. 重启后联网验证
+
+重新登录 VPS 后执行。`verify` 是只读验证，不会再次 apply，也不需要重新输入已经保存在状态中的端口带宽：
+
+```bash
+(
+  set -e
+
+  dvt_tmp="$(mktemp -d)"
+  trap 'rm -rf -- "$dvt_tmp"' EXIT
+
+  curl --fail --show-error --silent --location \
+    --proto '=https' \
+    --proto-redir '=https' \
+    --connect-timeout 15 \
+    --max-time 120 \
+    -o "$dvt_tmp/debian-vps-tuning.sh" \
+    https://github.com/alieismy/debian-vps-tuning/releases/download/v0.1.0-rc.9/debian-vps-tuning.sh
+
+  printf '%s  %s\n' \
+    '09cbb77591760fa1789729c31f64e03b29f145f50c8c419bca6057b23f492979' \
+    "$dvt_tmp/debian-vps-tuning.sh" | sha256sum -c -
+
+  bash "$dvt_tmp/debian-vps-tuning.sh" verify
+)
+
+printf 'verify_after_reboot_exit=%s\n' "$?"
+```
+
+`verify_after_reboot_exit=0` 才表示验证通过。保存完整输出；不要只截取最后一行。
+
+### 3. 安装 3X-UI 后严格联网验证
+
+推荐顺序是先完成调优和重启验证，再安装 3X-UI。安装并启动 3X-UI 后执行：
+
+```bash
+(
+  set -e
+
+  dvt_tmp="$(mktemp -d)"
+  trap 'rm -rf -- "$dvt_tmp"' EXIT
+
+  curl --fail --show-error --silent --location \
+    --proto '=https' \
+    --proto-redir '=https' \
+    --connect-timeout 15 \
+    --max-time 120 \
+    -o "$dvt_tmp/debian-vps-tuning.sh" \
+    https://github.com/alieismy/debian-vps-tuning/releases/download/v0.1.0-rc.9/debian-vps-tuning.sh
+
+  printf '%s  %s\n' \
+    '09cbb77591760fa1789729c31f64e03b29f145f50c8c419bca6057b23f492979' \
+    "$dvt_tmp/debian-vps-tuning.sh" | sha256sum -c -
+
+  env \
+    REQUIRE_PROXY_SERVICE=1 \
+    PROXY_SERVICE_UNITS='x-ui.service' \
+    bash "$dvt_tmp/debian-vps-tuning.sh" verify
+)
+
+printf 'strict_verify_after_3xui_exit=%s\n' "$?"
+```
+
+严格验证要求 `x-ui.service` 处于 active，并检查 systemd 配置、3X-UI 主进程和直接 Xray 子进程的 NOFILE soft/hard limit 均不低于 65536。安装 3X-UI 后再重启一次，并重复执行这条严格验证命令，才能证明开机启动和新进程继承仍然正确。
+
+### 4. 联网执行注意事项
+
+- 只支持厂商最小化 Debian 12/13、`x86_64/amd64` 和 README 列出的四个 CPU/内存资源档；其他组合会拒绝执行；
+- 端口带宽填写服务商套餐上限，不要填写虚拟网卡显示的链路速率；默认 200 Mbps，允许 100–1000 Mbps；
+- 联网入口固定到 `v0.1.0-rc.9`，不会回退到 `master`、`main`、`latest`、HTTP 或第三方镜像；
+- 上述命令在执行总控脚本前核对 rc.9 总控资产的固定 SHA-256；总控随后下载固定 Release 的 `SHA256SUMS` 和匹配 profile，并再次校验；
+- rc.9 Release 当前未启用 GitHub Release immutability；发布后不应移动 tag 或替换同名资产，发现缺陷时应发布新版本；
+- 脚本不配置或放行 UFW 端口，不要把 UFW 状态提示当成防火墙已配置；先确保 SSH 管理端口不会被锁死；
+- `apply` 会写入系统配置并可能创建 `/swapfile-proxy`；生产 VPS 应先备份、确认控制台/救援入口，并在维护窗口执行；
+- `verify` 通过证明当前配置和受检查服务符合脚本契约，不证明线路吞吐、延迟、丢包或 VLESS + REALITY + TCP 业务性能一定改善；
+- `rollback` 会撤销本项目管理的调优配置，应在维护窗口测试；普通 rollback 默认保留脚本创建的 swap；
+- 不要在未阅读脚本和发布说明时使用 `curl ... | bash` 或 `bash <(curl ...)`。
+
+## rc.9 真实环境验证状态
+
+2026-08-03 已取得一台真实 VPS 的主路径证据：
+
+| 项目 | 实测值 |
+|---|---|
+| 操作系统 | Debian GNU/Linux 13 (trixie) |
+| 内核 | `6.12.100+deb13-amd64` |
+| CPU / 内存 | 1 vCPU / 929 MiB，识别为 1C1GB |
+| 根文件系统 | ext4 |
+| 服务商端口上限 | 1000 Mbps |
+| profile | `debian13-1c1g` |
+| 总控/profile 版本 | `0.1.0-rc.9` |
+| profile SHA-256 | `9fd70c593b83d41337c6dfcada737855ce583e8bc3451ee8bb5952db850c81c6` |
+| 代理平台 | 3X-UI，systemd unit 为 `x-ui.service` |
+
+已通过：
+
+- 固定 rc.9 Release 总控、清单和 profile 的联网下载及 SHA-256 校验；
+- 交互安全引导、1000 Mbps 选择、`preflight`、首次 `apply` 和立即验证，均为退出码 0、警告 0；
+- 安装 3X-UI 前重启，联网 `verify` 退出码 0、警告 0；
+- 重启后 `proxy-vps-fq.service` 为 loaded/active/enabled，BBR、默认 fq、`eth0` 实际根 fq 和 `/swapfile-proxy` 均保持；
+- 安装 3X-UI 后严格验证，以及再次重启后的严格验证，均为退出码 0、警告 0；
+- 重启后 `x-ui.service` 主进程和直接 Xray 子进程的 NOFILE soft/hard limit 均为 65536/65536。
+
+该结果只证明 **Debian 13、1C1G、1000 Mbps、ext4、3X-UI** 这一组合的上述主路径。尚未在这台机器上完成无显式端口参数的重复 `apply`、rollback/purge、VLESS + REALITY + TCP 客户端连通性和 1/3/5/10 并发性能测试，也不能替代 Debian 12、512 MiB、2G、2C2G 或其他带宽组合的目标机证据。完整状态见 [验证矩阵](docs/validation.md)。
+
+## 本地使用与命令行模式
 
 `debian-vps-tuning.sh` 是总控入口。它自动读取 Debian 主版本、amd64 架构、可用逻辑 CPU 数和实际内存，在六份操作系统/内存 profile 中选择一份；用户不需要手工判断 512M/1G/2G 文件名。总控脚本不包含另一套调优逻辑，只负责选择、SHA-256 校验和调用。
 
@@ -15,14 +165,6 @@
 ```bash
 bash ./debian-vps-tuning.sh
 ```
-
-默认进入安全引导：
-
-1. 显示检测到的系统、CPU、内存和档位；
-2. 选择服务商端口带宽，直接按 Enter 使用 200 Mbps；
-3. 显示实际调用脚本、来源和 SHA-256；
-4. 先执行只读 `preflight`；
-5. `preflight` 通过后再次询问，只有明确输入 `y` 才执行 `apply`。
 
 直接使用命令行模式：
 
@@ -37,28 +179,6 @@ bash ./debian-vps-tuning.sh rollback
 
 在没有交互终端的自动化环境中必须明确指定 action；不会隐式进入菜单或自动 apply。`recover` 仍作为 rc.2 空状态的高级命令保留，但不出现在普通菜单中。
 
-### rc.9 发布后的快捷下载
-
-以下地址只有在 `v0.1.0-rc.9` 上传真实 Release assets 后才会生效；当前公开 rc.8 不包含总控脚本资产：
-
-```bash
-(
-  set -e
-  dvt_tmp="$(mktemp -d)"
-  trap 'rm -rf -- "$dvt_tmp"' EXIT
-  curl --fail --show-error --silent --location \
-    --proto '=https' \
-    --proto-redir '=https' \
-    --connect-timeout 15 \
-    --max-time 120 \
-    -o "$dvt_tmp/debian-vps-tuning.sh" \
-    https://github.com/alieismy/debian-vps-tuning/releases/download/v0.1.0-rc.9/debian-vps-tuning.sh
-  bash "$dvt_tmp/debian-vps-tuning.sh"
-)
-```
-
-这是便利入口，仍然要求信任 GitHub、仓库维护者和指定 Release。发布说明会同时给出总控脚本的固定 SHA-256，安全要求更高时应先核对哈希再执行。
-
 本项目不把下面的形式作为推荐入口：
 
 ```text
@@ -66,7 +186,7 @@ curl ... | bash
 bash <(curl ...)
 ```
 
-原因是它们在 root 权限下直接执行下载流，不具备独立的“下载完成 → 文件校验 → 再执行”门禁。总控脚本远程模式只下载固定 `v0.1.0-rc.9` Release，不回退到 `master`、`main`、`latest`、HTTP 或第三方镜像。
+原因是它们在 root 权限下直接执行下载流，不具备独立的“下载完成 → 文件校验 → 再执行”门禁。
 
 ## 适用场景
 

--- a/docs/releases/v0.1.0-rc.9.md
+++ b/docs/releases/v0.1.0-rc.9.md
@@ -1,4 +1,4 @@
-# v0.1.0-rc.9（发布草案）
+# v0.1.0-rc.9（Pre-release）
 
 这是 `debian-vps-tuning` 首发候选版本的第九轮变更，新增安全总控入口、512 MiB profile、按资源约束的缓冲/journald、3X-UI NOFILE 预置、常规 `pfifo_fast` 回滚和只读诊断，并把现有 2G 档位扩展为支持 1–2 vCPU。状态 schema 保持为 3。
 
@@ -20,7 +20,7 @@
 
 ## Release assets
 
-发布 draft 必须先上传并校验：
+已发布并校验以下固定资产：
 
 - `debian-vps-tuning.sh`；
 - `debian12-1c512m-vps-tuning.sh`；
@@ -31,7 +31,7 @@
 - `debian13-1c2g-vps-tuning.sh`；
 - `SHA256SUMS`。
 
-全部资产上传前不得发布；发布后不得移动 tag 或替换同名资产。若仓库支持 Release immutability，应在创建 rc.9 Release 前启用，并按“draft → 上传资产 → 校验 → 发布”的顺序操作。
+八个资产已从公开 Release 下载地址重新下载并通过 `SHA256SUMS`。发布后不得移动 tag 或替换同名资产；发现缺陷时发布新版本。当前仓库未启用 GitHub Release immutability。
 
 当前发布候选校验和：
 
@@ -54,9 +54,10 @@
 - 1536 MiB 边界、200 Mbps 默认值和 100–1000 Mbps 范围测试通过；
 - 清单重复、哈希不匹配、下载失败和底层退出码透传测试通过；
 - 六份 profile 与公共模板生成一致；
-- 既有状态机和 qdisc 故障注入测试通过。
-- `/etc/fstab` 过滤/替换失败保护和已安装非默认带宽的重复 `apply` fixture 通过。
+- 既有状态机和 qdisc 故障注入测试通过；
+- `/etc/fstab` 过滤/替换失败保护和已安装非默认带宽的重复 `apply` fixture 通过；
+- Debian 13、1C1G、1000 Mbps、ext4 目标机已通过固定 Release 联网下载、安全引导、首次 apply、安装 3X-UI 前重启验证、安装后严格验证及再次重启后的严格验证；`x-ui.service` 主进程和直接 Xray 子进程 NOFILE 均为 65536/65536。
 
 ## 发布边界
 
-rc.9 是预发行版。固定 Release assets 的真实下载只有发布后才能验证；交互确认、总控入口、512 MiB、2C2G、Debian 13、常规 `pfifo_fast` 和 1/3/5/10 并发业务矩阵仍需目标机证据。rc.8 的运行证据不能替代 rc.9 总控入口和 profile 版本的实机复测，因此不得标记为正式 `v0.1.0`。
+rc.9 是预发行版。上述实机只覆盖 Debian 13、1C1G、1000 Mbps、ext4 的主路径；该机的无显式端口重复 apply、rollback/purge、VLESS + REALITY + TCP 客户端连通性和 1/3/5/10 并发性能尚未完成。512 MiB、2G、2C2G、Debian 12 及其他带宽组合仍需目标机证据，因此不得标记为正式 `v0.1.0`。

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -25,13 +25,13 @@
 | C6 | 交互带宽直接 Enter | 使用 200 Mbps | fixture 通过 |
 | C7 | `--port` 和 `PORT_SPEED_MBPS` | 只接受 100–1000，显式参数优先 | fixture 通过 |
 | C8 | 清单缺失、重复条目、哈希不匹配 | 返回完整性错误，不调用 profile | fixture 通过 |
-| C9 | curl 失败、404、超时或中断 | 返回下载错误，不回退其他来源 | fixture 通过；真实 Release 待测 |
+| C9 | curl 失败、404、超时或中断 | 返回下载错误，不回退其他来源 | fixture 通过；目标 VPS 的真实下载失败路径未注入 |
 | C10 | profile 返回非零 | 控制器返回同一退出码 | fixture 通过 |
-| C11 | `guided` | preflight 通过后询问；N/Enter 不 apply | 目标 VPS 待测 |
+| C11 | `guided` | preflight 通过后询问；N/Enter 不 apply | rc.9 Debian 13 1C1G/1000 Mbps 的确认后 apply 路径通过；拒绝路径 fixture 通过 |
 | C12 | 菜单 `apply` | 再次确认；N/Enter 不 apply | 目标 VPS 待测 |
 | C13 | 无 TTY 且无 action | 返回 usage，不等待输入 | 目标 Linux 待测 |
 | C14 | 状态档位与检测档位不一致 | 阻断，不自动换 profile | fixture 通过；目标 VPS 待测 |
-| C15 | 固定 rc.9 Release assets | 下载清单和唯一 profile，SHA-256 通过 | 模拟远程 fixture 通过；rc.9 发布后待测 |
+| C15 | 固定 rc.9 Release assets | 下载清单和唯一 profile，SHA-256 通过 | fixture 和 Debian 13 1C1G/1000 Mbps 目标机通过；八个公开资产重新下载校验通过 |
 | C16 | 已安装状态下无 `--port`/环境变量地重复 `apply` | 复用状态中的端口带宽；显式参数仍优先；无效状态值阻断 | fixture 通过；目标 VPS 待测 |
 
 本地检查入口：
@@ -57,14 +57,14 @@ shellcheck -x \
 
 下表是必须取得证据的目标矩阵，不是已经完成的测试结果。没有真实 VPS 回填证据前，不得把状态改为“通过”。
 
-| ID | 系统 | 资源 | XFS SSD | 端口 | 内核基线 | 定位 | 状态 |
+| ID | 系统 | 资源 | 磁盘/根文件系统 | 端口 | 内核基线 | 定位 | 状态 |
 |---|---|---|---:|---:|---|---|---|
-| T1 | Debian 12 | 1C1G | 10 GB | 200 Mbps | `6.1.0-51-cloud-amd64` | 主力/首要门槛 | 待执行 |
-| T2 | Debian 12 | 1C2G | 15 GB | 200 Mbps | `6.1.0-51-cloud-amd64` | 主力/首要门槛 | rc.7 部分通过；rc.8 rollback 待复测 |
+| T1 | Debian 12 | 1C1G | 10 GB / XFS | 200 Mbps | `6.1.0-51-cloud-amd64` | 主力/首要门槛 | 待执行 |
+| T2 | Debian 12 | 1C2G | 15 GB / XFS | 200 Mbps | `6.1.0-51-cloud-amd64` | 主力/首要门槛 | rc.7 部分通过；rc.8 rollback 待复测 |
 | T3 | Debian 13 | 1C1G | 以实机为准 | 200 Mbps | `6.12.100+deb13-cloud-amd64` | 系统兼容 | 待执行 |
 | T4 | Debian 13 | 1C2G | 以实机为准 | 200 Mbps | `6.12.100+deb13-cloud-amd64` | 系统兼容 | 待执行 |
 | T5 | 与脚本匹配的 Debian 版本 | 1C1G | 10 GB | 100 Mbps | 以实机为准 | 低带宽边界 | 待执行 |
-| T6 | 与脚本匹配的 Debian 版本 | 1C1G | 50 GB | 1000 Mbps | 以实机为准 | 高带宽边界 | 待执行 |
+| T6 | Debian 13 | 1C1G | 容量未采集 / ext4 | 1000 Mbps | `6.12.100+deb13-amd64` | 高带宽边界 | rc.9 主路径通过；重复 apply、rollback、业务性能待执行 |
 | T7 | Debian 12 | 2C2G | 以实机为准 | 200 Mbps | `6.1.x`，以实机为准 | 2C2G 资源契约 | 待执行 |
 | T8 | Debian 13 | 2C2G | 以实机为准 | 200 Mbps | `6.12.x`，以实机为准 | 2C2G 系统兼容 | 待执行 |
 | T9 | Debian 12 | 1C512MB | 以实机为准 | 200 Mbps | `6.1.x`，以实机为准 | 最小内存边界 | 待执行 |
@@ -78,14 +78,14 @@ T1、T2 必须通过才能发布首个稳定版；T3、T4 是 Debian 13 稳定�
 
 | 阶段 | 操作 | 关键判据 | T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10 |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|
-| M0 | 基线采集 | OS、内核、CPU、内存、XFS、磁盘、双栈、qdisc、swap 可追溯 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 |
+| M0 | 基线采集 | OS、内核、CPU、内存、根文件系统、磁盘、双栈、qdisc、swap 可追溯 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 部分完成，磁盘容量与地址未采集 | 待执行 | 待执行 | 待执行 | 待执行 |
 | M1 | 未安装状态执行 `verify` | 退出码 5；提示先运行 `preflight`/`apply`；无系统写入 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 |
-| M2 | `preflight` | 退出码 0；识别资源档和文件系统；无系统写入 | 待执行 | rc.7 通过 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 |
-| M3 | `apply` | 退出码 0；状态为 `VERIFIED`；含 NOFILE drop-in，swap/qdisc 符合预期 | 待执行 | rc.7 通过 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 |
-| M4 | 立即 `verify` | 退出码 0；sysctl、qdisc、journald、swap、drop-in 一致 | 待执行 | rc.7 通过 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 |
-| M5 | 重启后 `verify` | 退出码 0；BBR、fq、sysctl、swap 持久 | 待执行 | rc.7 通过 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 |
+| M2 | `preflight` | 退出码 0；识别资源档和文件系统；无系统写入 | 待执行 | rc.7 通过 | 待执行 | 待执行 | 待执行 | rc.9 通过 | 待执行 | 待执行 | 待执行 | 待执行 |
+| M3 | `apply` | 退出码 0；状态为 `VERIFIED`；含 NOFILE drop-in，swap/qdisc 符合预期 | 待执行 | rc.7 通过 | 待执行 | 待执行 | 待执行 | rc.9 通过 | 待执行 | 待执行 | 待执行 | 待执行 |
+| M4 | 立即 `verify` | 退出码 0；sysctl、qdisc、journald、swap、drop-in 一致 | 待执行 | rc.7 通过 | 待执行 | 待执行 | 待执行 | rc.9 通过 | 待执行 | 待执行 | 待执行 | 待执行 |
+| M5 | 重启后 `verify` | 退出码 0；BBR、fq、sysctl、swap 持久 | 待执行 | rc.7 通过 | 待执行 | 待执行 | 待执行 | rc.9 通过 | 待执行 | 待执行 | 待执行 | 待执行 |
 | M6 | 重复 `apply` | 退出码 0；报告无需重复写入；无重复 fstab/unit | 待执行 | rc.7 通过 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 |
-| M7 | 安装 3X-UI 后严格验证 | `REQUIRE_PROXY_SERVICE=1 verify` 通过；x-ui/Xray 运行时 NOFILE ≥ 65536 | 待执行 | rc.7 通过 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 |
+| M7 | 安装 3X-UI 后严格验证 | `REQUIRE_PROXY_SERVICE=1 verify` 通过；x-ui/Xray 运行时 NOFILE ≥ 65536 | 待执行 | rc.7 通过 | 待执行 | 待执行 | 待执行 | rc.9 安装后及再次重启后通过 | 待执行 | 待执行 | 待执行 | 待执行 |
 | M8 | VLESS + REALITY + TCP | IPv4/IPv6 按实际能力建立连接；连续传输无异常 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 |
 | M9 | 普通 `rollback` | 恢复 qdisc/sysctl，删除 drop-in；脚本 swap 默认保留；状态可追溯 | 待执行 | rc.7 实际恢复通过；rc.8 后置验证待复测 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 |
 | M10 | 回滚后重启 | `status` 正确；无残留 unit/sysctl/journald/drop-in | 待执行 | rc.7 通过 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 | 待执行 |
@@ -138,6 +138,8 @@ sysctl 校验应比较归一化后的字段值：内核通过 `sysctl -n` 返回
 2026-08-02，Debian 12 1C1G、1000 Mbps 目标机使用 rc.6 完成受控空状态恢复，随后 `preflight` 通过。`apply` 已写入并切换到 fq，但 `verify` 把 `tcp_rmem`/`tcp_wmem` 的制表符对齐误判为值不一致，因此事务按设计自动回滚；日志确认“回滚完成，管理状态已清理”。这证明 recover 和该次失败回滚路径通过，不代表 M3 apply 通过，也不代表 rc.7 已在目标机通过。
 
 2026-08-02，Debian 12 1C2G、200 Mbps、已有外部 `/swapfile-3xui` 的目标机使用 SHA-256 `8c241f3a5c58ab34c5d7286621ab52e2552dd17cdeaa4aa1c46137c17d53d7e4` 的 rc.7 完成干净迁移、preflight、apply、立即/重启后 verify、重复 apply、严格 3X-UI verify、rollback、回滚后重启、重新 apply 和最终重启后严格 verify。rollback 立即恢复为功能参数一致的 `fq_codel`，内核自动分配 `handle 8001:`，时间字段回显比快照少 1 微秒；重启后恢复为原始 `handle 0:`、`target 4999`、`interval 99999`。外部 swap 始终保留，x-ui/Xray 始终活动。该证据证明 rc.7 实际生命周期成功，同时暴露其恢复命令后缺少删除状态前语义复核；rc.8 已修复但尚未取得目标机运行证据。
+
+2026-08-03，Debian 13 1C1G、929 MiB、1000 Mbps、ext4、内核 `6.12.100+deb13-amd64` 的目标机使用固定 `v0.1.0-rc.9` Release 总控入口，自动选择 `debian13-1c1g-vps-tuning.sh`，profile SHA-256 为 `9fd70c593b83d41337c6dfcada737855ce583e8bc3451ee8bb5952db850c81c6`。安全引导、preflight、首次 apply 和立即验证均为退出码 0、警告 0；安装 3X-UI 前重启后联网 verify 通过，`proxy-vps-fq.service` 为 loaded/active/enabled，BBR、默认 fq、`eth0` 实际根 fq 和 1024 MiB `/swapfile-proxy` 均保持。安装 3X-UI 后严格 verify 通过，再次重启后严格 verify 仍通过；新 `x-ui.service` 主进程和直接 Xray 子进程 NOFILE soft/hard 均为 65536/65536。该证据覆盖 T6 的 M2–M5、M7 和固定 Release 真实下载，不覆盖 M0 完整基线、M1、M6、M8–M11，也不证明业务性能。
 
 qdisc 快照往返测试必须区分显示单位和命令输入：不得把文本输出的 `p` 后缀拼入 `limit`；`memory_limit` 使用 `tc -j` 返回的原始字节整数。`target`、`interval` 和 `ce_threshold` 可容忍 ±1 微秒回显量化差异。快照 `handle 0:` 与内核自动分配的 classless qdisc handle 视为等价；显式非零 handle、kind、parent、root 及其他 options 仍严格比较。恢复命令成功后还必须执行后置语义比较；不一致时保留状态和快照并进入 `DEGRADED`。
 


### PR DESCRIPTION
## 背景

rc.9 已经发布，但 README 前部仍保留发布前表述，也缺少可以直接复制使用的安全联网安装、重启后验证和安装 3X-UI 后严格验证命令。

本次同时记录 Debian 13、1C1G、1000 Mbps、ext4 目标 VPS 的真实主路径结果，避免把本地静态检查与目标机证据混为一谈。

## 修改内容

- 在 README 前部增加固定 rc.9 Release 的联网安装流程；
- 在执行前校验总控脚本 SHA-256，由总控继续校验清单和 profile；
- 增加重启后联网 verify 和安装 3X-UI 后严格 verify 命令；
- 前置适用范围、root、UFW、回滚、Release immutability 和性能边界等注意事项；
- 更新 CHANGELOG、rc.9 发布说明和目标 VPS 验证矩阵；
- 记录 Debian 13、1C1G、929 MiB、1000 Mbps、ext4、3X-UI 的实际验证证据及未覆盖项。

## 影响

用户可以在不手工下载项目文件的情况下安全安装和验证 rc.9。文档继续将 rc.9 标记为 Pre-release，不把单一 VPS 主路径结果表述为完整生命周期或业务性能验收。

这是 rc.9 发布后的文档补充。PR 合并到 `master`；不会移动已有 `v0.1.0-rc.9` tag，也不会替换同名 Release 资产。

## 验证

- `bash tests/controller-check.sh`
- `python tools/render_profiles.py --check`
- `sha256sum -c SHA256SUMS`
- `git diff --check`
- README Bash 代码块语法、Markdown 结构、链接、LF/no-BOM 和敏感信息检查
- rc.9 八个公开 Release 资产重新下载并通过发布清单校验


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release guidance for the published `v0.1.0-rc.9` release.
  * Added fixed download instructions with HTTPS requirements and SHA-256 verification.
  * Documented installation, reboot, and post-installation validation procedures.
  * Expanded Debian 13 validation records, including security, filesystem, network, and service checks.
  * Clarified completed coverage and remaining validation areas in the release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->